### PR TITLE
feat: add question delete for mentors, fix answer editing UX and uplo…

### DIFF
--- a/src/components/common/questionBox.vue
+++ b/src/components/common/questionBox.vue
@@ -9,6 +9,15 @@
         </div>
       </div>
     </div>
+    <div class="delete-modal-overlay" v-if="showDeleteQuestionModal" @click.self="showDeleteQuestionModal = false">
+      <div class="delete-modal">
+        <h3>Are you sure you want to<br/>delete this question?</h3>
+        <div class="modal-actions">
+          <button class="btn-delete-confirm" type="button" @click.stop="confirmDeleteQuestion">Delete</button>
+          <button class="btn-cancel" type="button" @click.stop="showDeleteQuestionModal = false">Cancel</button>
+        </div>
+      </div>
+    </div>
     <article class="question-card" :class="{ answered: isAnswered }">
       <button class="question-content" type="button" @click="openQuestion">
         <div class="question-main">
@@ -46,6 +55,9 @@
           </span>
           <button v-if="(AuthStore.role == 5980 || AuthStore.role == 6311) && !isAnswered" class="answer-pill-yellow" type="button" @click.stop="toggleInlineAnswer(false)">
             Answer
+          </button>
+          <button v-if="AuthStore.role == 5980" class="icon-btn" type="button" @click.stop="deleteQuestion" aria-label="Delete Question">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
           </button>
         </div>
       </button>
@@ -191,6 +203,7 @@ export default {
       isEditingAnswer: false,
       inlineAnswerBody: "",
       showDeleteModal: false,
+      showDeleteQuestionModal: false,
     };
   },
   computed: {
@@ -333,6 +346,9 @@ export default {
     async deleteAnswer() {
       this.showDeleteModal = true;
     },
+    async deleteQuestion() {
+      this.showDeleteQuestionModal = true;
+    },
     async EditAnswerClick() {
       await this.QuestionStore.SetQuestion(this.question);
       await this.QuestionStore.SetAction(8);
@@ -387,6 +403,12 @@ export default {
         await this.QuestionStore.DeleteAnswer();
       }
       this.showDeleteModal = false;
+    },
+    async confirmDeleteQuestion() {
+      await this.QuestionStore.SetQuestion(this.question);
+      await this.QuestionStore.SetQuestionID(this.question._id || this.question.id);
+      await this.QuestionStore.DeleteQuestion();
+      this.showDeleteQuestionModal = false;
     },
     async Hide() {
       await this.QuestionStore.SetQuestion(this.question);
@@ -692,7 +714,8 @@ export default {
   flex-shrink: 0;
 }
 
-.answer-actions .icon-btn {
+.answer-actions .icon-btn,
+.question-side .icon-btn {
   width: 28px;
   height: 28px;
   border-radius: 50%;

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -1089,6 +1089,64 @@ export const useQuestionStore = defineStore("question", {
       }
     },
 
+    async DeleteQuestion() {
+      const authStore = useAuthStore();
+      const listStore = useListStore();
+      const colourStore = useColourStore();
+
+      const bearer = `Bearer ${authStore.accessToken}`;
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE}/question/deleteQ/${this.question_ID}`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: bearer,
+          },
+        }
+      );
+      
+      this.showSnackbar = true;
+
+      if (res.status == 200) {
+        const data = await res.json();
+        this.snackMessage = data.message;
+        colourStore.SetSnackColor(true);
+        await listStore.SetDeleteQuestion(this.question_ID);
+        return true;
+      } else {
+        if (res.status === 403) {
+          await authStore.Refresh()
+          if (authStore.loggedIn) {
+            const bearer = `Bearer ${authStore.accessToken}`;
+            const res = await fetch(
+              `${import.meta.env.VITE_API_BASE}/question/deleteQ/${this.question_ID}`,
+              {
+                method: "DELETE",
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: bearer,
+                },
+              }
+            )
+            const data = await res.json();
+            this.snackMessage = data.message;
+            colourStore.SetSnackColor(true);
+            await listStore.SetDeleteQuestion(this.question_ID);
+            return true;
+          } else {
+            await authStore.Logout();
+            return false;
+          }
+        } else {
+          this.snackMessage = "not enough permissions";
+          colourStore.SetSnackColor(false);
+          await authStore.Logout();
+          return false;
+        }
+      }
+    },
+
     async HideQuestionComment() {
       const authStore = useAuthStore();
       const listStore = useListStore();


### PR DESCRIPTION
## Description
This PR adds the ability for SMP mentors to delete questions directly from the question list, and fixes several UX issues around the answer editing flow.

### Key Changes
- **Delete Question**: Added a circular trash icon button (matching the existing answer delete icon) next to each question, visible only to SMP admins. Includes a confirmation modal and uses the existing `DELETE /question/deleteQ/:qid` backend route.
- **Inline (edited) Tag**: Fixed CSS so the `(edited)` tag renders on the same line as "Answer from SMP" instead of dropping to a new line.
- **Instant Edit Feedback**: The `(edited)` tag now appears immediately after a successful edit without requiring a page refresh.
- **Upload Validation**: Added client-side guards that reject non-image files (only JPEG/PNG/GIF allowed) and files over 10MB with a browser alert.
- **Edit Mode Cleanup**: Disabled the "Add attachment" button while editing an answer since the edit endpoint only supports text changes.
- **Hide Button Removed**: Commented out the Hide button on Questionview to prevent mentors from accidentally hiding questions from the feed.

### How to Test
1. Log in as SMP. On the question list, you should see a trash icon next to each question — click it, confirm, and verify the question is removed.
2. Edit an existing answer — verify `(edited)` appears inline instantly.
3. Try uploading a PDF or a >10MB file while answering — verify the browser alert blocks it.
4. While editing an answer, verify the "Add attachment" button is not visible.
