### PR TITLE
fix: resolve state reactivity issues on infopost CRUD and list rendering

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -96,7 +96,7 @@
         
         <!-- Mobile Floating Action Button (FAB) -->
         <button
-          v-if="windowWidth < 750 && Auth.role != 6311"
+          v-if="windowWidth < 750 && Auth.role != 6311 && !askQuestion"
           class="mobile-fab"
           type="button"
           @click="postInfoQues"

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -373,6 +373,10 @@ export const useQuestionStore = defineStore("question", {
         const data = await res.json();
         console.log('data :', data);
         this.snackMessage = data.message;
+        const listStore = useListStore();
+        if (data.data) {
+          listStore.list.unshift(data.data);
+        }
         await colourStore.SetSnackColor(true);
       } else {
         if (res.status === 403) {
@@ -396,8 +400,11 @@ export const useQuestionStore = defineStore("question", {
             console.log("snackbar");
             console.log("new request sent");
             const data = await res.json();
-            console.log('data :', data);
             this.snackMessage = data.message;
+            const listStore = useListStore();
+            if (data.data) {
+              listStore.list.unshift(data.data);
+            }
           } else {
             console.log("refresh failed");
             await this.authStore.Logout();
@@ -1453,60 +1460,7 @@ export const useQuestionStore = defineStore("question", {
         }
       }
     },
-    async DeleteInfoPost() {
-      const authStore = useAuthStore();
-      const listStore = useListStore();
-      const colourStore = useColourStore();
-      console.log("deleting infopost in question.js", this.info_ID);
 
-      const accessToken = authStore.accessToken;
-      const bearer = `Bearer ${accessToken}`;
-
-      const res = await fetch(`${import.meta.env.VITE_API_BASE}/info/delete/${this.info_ID}`, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: bearer,
-        },
-      });
-
-      this.showSnackbar = true;
-      if (res.status == 200) {
-        console.log("successfully deleted the info post :", this.info_ID);
-        const data = await res.json();
-        this.snackMessage = data.message;
-        colourStore.SetSnackColor(true);
-        // Assuming we need to remove from listStore. Let's filter out the deleted infopost in listStore or let component reload
-        listStore.list = listStore.list.filter(item => item._id !== this.info_ID && item.id !== this.info_ID);
-      } else {
-        if (res.status === 403) {
-          await authStore.Refresh();
-          if (authStore.loggedIn) {
-            const bearer = `Bearer ${authStore.accessToken}`;
-            const res = await fetch(`${import.meta.env.VITE_API_BASE}/info/delete/${this.info_ID}`, {
-              method: "DELETE",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: bearer,
-              },
-            });
-            this.showSnackbar = true;
-            const data = await res.json();
-            this.snackMessage = data.message;
-            colourStore.SetSnackColor(true);
-            listStore.list = listStore.list.filter(item => item._id !== this.info_ID && item.id !== this.info_ID);
-            return data;
-          } else {
-            await this.authStore.Logout();
-          }
-        } else {
-          this.showSnackbar = true;
-          this.snackMessage = "not enough permissions";
-          colourStore.SetSnackColor(false);
-          await this.authStore.Logout();
-        }
-      }
-    },
     async EditAnswer(body) {
       const authStore = useAuthStore();
       const listStore = useListStore();

--- a/src/views/Answered.vue
+++ b/src/views/Answered.vue
@@ -57,11 +57,13 @@ export default {
   },
   data() {
     return {
-      questions: [],
       searchQuery: "",
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       if (!this.searchQuery.trim()) return this.questions;
       const fuse = new Fuse(this.questions, {
@@ -143,7 +145,6 @@ export default {
       this.questionStore.FetchAnnouncementsCount(),
       this.questionStore.FetchUnansweredCount()
     ]);
-    this.questions = this.listStore.list;
     console.log(this.questions);
     this.colourStore.colourAnswered();
   },

--- a/src/views/Infopost.vue
+++ b/src/views/Infopost.vue
@@ -78,13 +78,15 @@ export default {
   data() {
     return {
       networkError: false,
-      infoposts: [],
       searchQuery: "",
       windowWidth: window.innerWidth,
     };
   },
 
   computed: {
+    infoposts() {
+      return this.listStore.list || [];
+    },
     filteredInfoposts() {
       if (!this.searchQuery.trim()) {
         return this.infoposts;
@@ -201,9 +203,6 @@ export default {
       console.log("Selected tag:", tag);
 
       await this.fetchInfoPosts(tag);
-
-      this.infoposts = this.listStore.list;
-
       console.log(this.infoposts);
     },
     handleResize() {
@@ -217,7 +216,6 @@ export default {
       this.questionStore.FetchUnansweredCount()
     ]);
 
-    this.infoposts = this.listStore.list;
     this.questionStore.announcementsCount = this.infoposts.length;
 
     console.log(this.infoposts);

--- a/src/views/MyQuestions.vue
+++ b/src/views/MyQuestions.vue
@@ -64,11 +64,13 @@ export default {
   data() {
     return {
       networkError: false,
-      questions: [],
       searchQuery: "",
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       if (!this.searchQuery.trim()) {
         return this.questions;
@@ -152,7 +154,6 @@ export default {
   async mounted() {
     await this.colourStore.colourMyQuestions();
     await this.fetchQuestions();
-    this.questions = this.listStore.list || [];
     console.log(this.questions);
   },
 };

--- a/src/views/Questions.vue
+++ b/src/views/Questions.vue
@@ -101,7 +101,6 @@ export default {
   data() {
     return {
       networkError: false,
-      questions: [],
       searchQuery: "",
       categories: [
         "Hostel",
@@ -120,6 +119,9 @@ export default {
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       let result = [...this.questions];
 
@@ -233,7 +235,6 @@ export default {
     },
     async handleTagSelected(tag) {
       await this.fetchQuestions(tag);
-      this.questions = this.listStore.list || [];
     },
     handleResize() {
       this.windowWidth = window.innerWidth;
@@ -275,7 +276,6 @@ export default {
       this.questionStore.FetchAnnouncementsCount(),
       this.questionStore.FetchUnansweredCount()
     ]);
-    this.questions = this.listStore.list || [];
     this.colourStore.colourQuestions();
     window.addEventListener("resize", this.handleResize);
   },

--- a/src/views/UnAnswered.vue
+++ b/src/views/UnAnswered.vue
@@ -57,11 +57,13 @@ export default {
   },
   data() {
     return {
-      questions: [],
       searchQuery: "",
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       if (!this.searchQuery.trim()) return this.questions;
       const fuse = new Fuse(this.questions, {
@@ -143,7 +145,6 @@ export default {
       this.questionStore.FetchAnnouncementsCount(),
       this.questionStore.FetchUnansweredCount()
     ]);
-    this.questions = this.listStore.list;
     console.log(this.questions);
     this.colourStore.colourUnAnswered();
   },


### PR DESCRIPTION
## Description
This PR resolves state management and reactivity bugs that required users to refresh the page to see newly created or deleted content (such as Announcements and Questions). It also fixes an overlapping UI bug with the mobile Floating Action Button.

### Key Changes
- **Computed List Properties:** Refactored `Infopost.vue`, `MyQuestions.vue`, `Questions.vue`, `Answered.vue`, and `UnAnswered.vue` to use `computed` properties for `infoposts` and `questions`. This fixes the bug where components cached the store's array in their static `data()` state upon mounting, breaking reactivity when the `listStore` mutated.
- **Immediate Feedback on Creation:** Modified the `PostInfoPost` action in `question.js` to `unshift` the backend's response object directly into the `listStore`. Announcements now appear at the top of the feed instantly.
- **Store Cleanup:** Removed an erroneously duplicated `DeleteInfoPost` function in the `question.js` store that was overriding logic.
- **Mobile UI Fix:** Added a `v-if` condition (`!askQuestion`) to `App.vue` so the mobile "Ask question" floating action button is completely hidden while the `askBox` is actively open.

### How to test
1. Log in as an SMP Mentor and navigate to the Announcements page.
2. Create an announcement -> It should appear instantly without a refresh.
3. Delete an announcement -> It should disappear instantly without a refresh.
4. Open the mobile view (width < 750px) and hit the floating `Ask Question` button -> Verify the floating button disappears while the question modal is on screen.
