### PR TITLE
fix: auto-collapse mobile menus on navigation or task start

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -260,6 +260,16 @@ export default {
   },
   
   watch: {
+    $route() {
+      this.showSidebar = false;
+      this.showDropdown = false;
+    },
+    askQuestion(newVal) {
+      if (newVal) {
+        this.showSidebar = false;
+        this.showDropdown = false;
+      }
+    },
     "QuestionStore.showSnackbar"(newValue) {
       if (newValue === true) {
         this.localSnackbarOverride = false;


### PR DESCRIPTION
## Description
This PR fixes a UI/UX bug on mobile viewports where the navigation menus (the left sidebar and the top-right dropdown) remained open and obstructed the screen after a user interacted with the app.

### Key Changes
- **Auto-collapsing Mobile Menus:** Added watchers in `App.vue` for `$route` and `askQuestion`. When a user navigates to a new page (e.g., clicking on a suggested question link) or opens the "Ask Question" modal, both `showSidebar` and `showDropdown` are automatically set to `false`.

### How to test
1. On a mobile viewport (< 750px), open the top-right hamburger (dropdown) menu or the left sidebar menu. 
2. Click on a link or trigger the "Ask question" modal.
3. Verify that the menu immediately collapses and no longer obstructs the screen while you are viewing the new route or typing your question.
