### PR TITLE
fix: resolve notification logic and auto-collapse overlapping menus

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -230,11 +230,24 @@ export default {
       return this.Auth.role == 5980 ? "Create Announcement" : "Ask question";
     },
     notificationItems() {
-      const items = Array.isArray(this.ListStore.list) ? this.ListStore.list : [];
+      const items = Array.isArray(this.ListStore.list) ? [...this.ListStore.list] : [];
+      
+      // Sort newest first
+      items.sort((a, b) => {
+        const dateA = new Date(a.asked_At || a.createdAt || 0);
+        const dateB = new Date(b.asked_At || b.createdAt || 0);
+        return dateB - dateA;
+      });
+
       const fallbackTitle = "What are the best electives for first-year CS students?";
       const fallbackBody =
         "The answer will be here. The answer will be here. The answer will be here. The answer will be here. The answer will be here.";
-      const candidates = items.filter((item) => item && item.body).slice(0, 2);
+      const candidates = items.filter((item) => {
+        if (!item || !item.body) return false;
+        if (item.title) return true;
+        if (item.answers && item.answers.length > 0) return true;
+        return false;
+      }).slice(0, 2);
 
       if (!candidates.length) {
         return [1, 2].map((id) => ({
@@ -246,16 +259,30 @@ export default {
         }));
       }
 
-      return candidates.map((item, index) => ({
-        id: item._id || item.id || index,
-        kicker: "Your question was answered by ISMP Priya",
-        title: item.title || item.body || fallbackTitle,
-        body:
-          item.answers && item.answers.length
+      return candidates.map((item, index) => {
+        const isAnnouncement = !!item.title;
+        let kicker, title, body;
+
+        if (isAnnouncement) {
+          kicker = "New Announcement from SMP";
+          title = item.title;
+          body = item.body;
+        } else {
+          kicker = "Your question was answered by ISMP Priya";
+          title = item.body || fallbackTitle;
+          body = item.answers && item.answers.length
             ? item.answers[0].body || fallbackBody
-            : fallbackBody,
-        time: this.formatShortDate(item.asked_At),
-      }));
+            : fallbackBody;
+        }
+
+        return {
+          id: item._id || item.id || index,
+          kicker,
+          title,
+          body,
+          time: this.formatShortDate(item.asked_At || item.createdAt || new Date()),
+        };
+      });
     },
   },
   

--- a/src/components/common/Navbar.vue
+++ b/src/components/common/Navbar.vue
@@ -15,7 +15,7 @@
         type="button"
         class="nav-icon bell-icon"
         :class="{ active: notificationsOpen }"
-        @click="$emit('toggleNotifications')"
+        @click="handleToggleNotifications"
         aria-label="Open notifications"
       >
         <Notification class="notification-svg" />
@@ -76,9 +76,16 @@ export default {
   },
   mounted() {
     window.addEventListener("resize", this.handleResize);
+    document.addEventListener("click", this.closeDropdown);
   },
   beforeUnmount() {
     window.removeEventListener("resize", this.handleResize);
+    document.removeEventListener("click", this.closeDropdown);
+  },
+  watch: {
+    $route() {
+      this.showLogoutMenu = false;
+    }
   },
   computed: {
     isMobile() {
@@ -95,11 +102,26 @@ export default {
     handleResize() {
       this.windowWidth = window.innerWidth;
     },
+    closeDropdown(e) {
+      const userProfile = this.$el.querySelector('.user-profile');
+      if (this.showLogoutMenu && userProfile && !userProfile.contains(e.target)) {
+        this.showLogoutMenu = false;
+      }
+    },
     toDevCom() {
       window.open("https://devcom.gymkhana.iitb.ac.in/");
     },
+    handleToggleNotifications() {
+      if (this.showLogoutMenu) {
+        this.showLogoutMenu = false;
+      }
+      this.$emit("toggleNotifications");
+    },
     toggleLogoutMenu() {
       this.showLogoutMenu = !this.showLogoutMenu;
+      if (this.showLogoutMenu && this.notificationsOpen) {
+        this.$emit("toggleNotifications");
+      }
     },
     async handleLogout() {
       await this.authStore.Logout();


### PR DESCRIPTION
## Description
This PR addresses several UI/UX bugs related to state mismatches in the notifications panel, menu overlaps in the navigation bar, and local state update failures during answer editing.

### Key Changes
- **Notification Data Accuracy:** Refactored `notificationItems` in `App.vue`. Previously, it blindly assumed all items were questions, grabbed the oldest records in the database, and showed fallback text for missing data. It now:
  1. Actively sorts the local feed by `asked_At` descending to ensure only the absolute newest items are grabbed.
  2. Filters out unanswered questions so the dropdown accurately displays only actionable notifications.
  3. Properly differentiates between `body` parsing for Announcements vs `answers[0].body` for Questions.
- **Menu Overlap Management (`Navbar.vue`):** 
  - Added mutual toggle checks: clicking the notifications bell now automatically dismisses the logout dropdown, and vice-versa.
  - Added a global document `click` listener and a `$route` watcher to the Logout dropdown. It will now automatically collapse if the user clicks anywhere outside the profile element or navigates to a new page.
- **Edit State Fixes:** Updated `SetEditAnswer` in `list.js` to use safe `_id` vs `id` fallbacks when parsing the local state, and correctly sets `edited = true` to force Vue to instantly re-render the edited answer without a page refresh.

### How to test
1. Log in and navigate to the Student dashboard.
2. Ensure you have recently answered anonymous questions. Open the notification bell and verify that the newest answered question is at the top, rather than older cached questions or placeholder texts.
3. In the top right `Navbar`, click your profile to open the Logout menu.
4. Click anywhere else on the screen (or navigate to a different page/tab). The Logout menu should dismiss itself.
5. Open the Notifications menu and then click your profile. The notifications menu should close automatically as the Logout menu opens.
