### PR TITLE
Fix/mobile attachments and UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -230,11 +230,24 @@ export default {
       return this.Auth.role == 5980 ? "Create Announcement" : "Ask question";
     },
     notificationItems() {
-      const items = Array.isArray(this.ListStore.list) ? this.ListStore.list : [];
+      const items = Array.isArray(this.ListStore.list) ? [...this.ListStore.list] : [];
+      
+      // Sort newest first
+      items.sort((a, b) => {
+        const dateA = new Date(a.asked_At || a.createdAt || 0);
+        const dateB = new Date(b.asked_At || b.createdAt || 0);
+        return dateB - dateA;
+      });
+
       const fallbackTitle = "What are the best electives for first-year CS students?";
       const fallbackBody =
         "The answer will be here. The answer will be here. The answer will be here. The answer will be here. The answer will be here.";
-      const candidates = items.filter((item) => item && item.body).slice(0, 2);
+      const candidates = items.filter((item) => {
+        if (!item || !item.body) return false;
+        if (item.title) return true;
+        if (item.answers && item.answers.length > 0) return true;
+        return false;
+      }).slice(0, 2);
 
       if (!candidates.length) {
         return [1, 2].map((id) => ({
@@ -246,16 +259,30 @@ export default {
         }));
       }
 
-      return candidates.map((item, index) => ({
-        id: item._id || item.id || index,
-        kicker: "Your question was answered by ISMP Priya",
-        title: item.title || item.body || fallbackTitle,
-        body:
-          item.answers && item.answers.length
+      return candidates.map((item, index) => {
+        const isAnnouncement = !!item.title;
+        let kicker, title, body;
+
+        if (isAnnouncement) {
+          kicker = "New Announcement from SMP";
+          title = item.title;
+          body = item.body;
+        } else {
+          kicker = "Your question was answered by ISMP Priya";
+          title = item.body || fallbackTitle;
+          body = item.answers && item.answers.length
             ? item.answers[0].body || fallbackBody
-            : fallbackBody,
-        time: this.formatShortDate(item.asked_At),
-      }));
+            : fallbackBody;
+        }
+
+        return {
+          id: item._id || item.id || index,
+          kicker,
+          title,
+          body,
+          time: this.formatShortDate(item.asked_At || item.createdAt || new Date()),
+        };
+      });
     },
   },
   

--- a/src/App.vue
+++ b/src/App.vue
@@ -96,7 +96,7 @@
         
         <!-- Mobile Floating Action Button (FAB) -->
         <button
-          v-if="windowWidth < 750 && Auth.role != 6311"
+          v-if="windowWidth < 750 && Auth.role != 6311 && !askQuestion"
           class="mobile-fab"
           type="button"
           @click="postInfoQues"

--- a/src/App.vue
+++ b/src/App.vue
@@ -260,6 +260,16 @@ export default {
   },
   
   watch: {
+    $route() {
+      this.showSidebar = false;
+      this.showDropdown = false;
+    },
+    askQuestion(newVal) {
+      if (newVal) {
+        this.showSidebar = false;
+        this.showDropdown = false;
+      }
+    },
     "QuestionStore.showSnackbar"(newValue) {
       if (newValue === true) {
         this.localSnackbarOverride = false;

--- a/src/components/common/Navbar.vue
+++ b/src/components/common/Navbar.vue
@@ -15,7 +15,7 @@
         type="button"
         class="nav-icon bell-icon"
         :class="{ active: notificationsOpen }"
-        @click="$emit('toggleNotifications')"
+        @click="handleToggleNotifications"
         aria-label="Open notifications"
       >
         <Notification class="notification-svg" />
@@ -76,9 +76,16 @@ export default {
   },
   mounted() {
     window.addEventListener("resize", this.handleResize);
+    document.addEventListener("click", this.closeDropdown);
   },
   beforeUnmount() {
     window.removeEventListener("resize", this.handleResize);
+    document.removeEventListener("click", this.closeDropdown);
+  },
+  watch: {
+    $route() {
+      this.showLogoutMenu = false;
+    }
   },
   computed: {
     isMobile() {
@@ -95,11 +102,26 @@ export default {
     handleResize() {
       this.windowWidth = window.innerWidth;
     },
+    closeDropdown(e) {
+      const userProfile = this.$el.querySelector('.user-profile');
+      if (this.showLogoutMenu && userProfile && !userProfile.contains(e.target)) {
+        this.showLogoutMenu = false;
+      }
+    },
     toDevCom() {
       window.open("https://devcom.gymkhana.iitb.ac.in/");
     },
+    handleToggleNotifications() {
+      if (this.showLogoutMenu) {
+        this.showLogoutMenu = false;
+      }
+      this.$emit("toggleNotifications");
+    },
     toggleLogoutMenu() {
       this.showLogoutMenu = !this.showLogoutMenu;
+      if (this.showLogoutMenu && this.notificationsOpen) {
+        this.$emit("toggleNotifications");
+      }
     },
     async handleLogout() {
       await this.authStore.Logout();

--- a/src/components/common/questionBox.vue
+++ b/src/components/common/questionBox.vue
@@ -66,20 +66,19 @@
         <div class="inline-input-wrapper">
           <textarea v-model="inlineAnswerBody" placeholder="Answer a question" class="inline-textarea"></textarea>
           <div class="inline-input-bottom">
-            <button v-if="!isEditingAnswer" class="add-attachment-btn" type="button" @click="AddInlineImages">
+            <button class="add-attachment-btn" type="button" @click="$refs.fileInput.click()">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path>
               </svg>
               Add attachment
             </button>
-            <input ref="inlineFileInput" type="file" @change="SelectInlineFiles" multiple style="display: none;" />
-          </div>
-        </div>
-        
-        <div class="inline-preview" v-if="inlinePreviewImages.length > 0">
-          <div v-for="(image, index) in inlinePreviewImages" :key="index" class="PreImage">
-            <button class="cancel" type="button" @click.stop="RemoveInlineImage(index)" aria-label="Remove attachment"></button>
-            <img :src="image" alt="Preview Image" />
+            <input type="file" ref="fileInput" @change="handleFileUpload" style="display: none" multiple accept="image/*" />
+            <div v-if="inlineImages.length > 0" class="selected-images">
+              <span v-for="(img, idx) in inlineImages" :key="idx" class="image-pill">
+                {{ img.name }}
+                <button type="button" @click="removeInlineImage(idx)">&times;</button>
+              </span>
+            </div>
           </div>
         </div>
         <div class="inline-answer-actions">
@@ -253,8 +252,7 @@ export default {
       isAnswering: false,
       isEditingAnswer: false,
       inlineAnswerBody: "",
-      inlineSelectedImages: [],
-      inlinePreviewImages: [],
+      inlineImages: [],
       showDeleteModal: false,
       showDeleteQuestionModal: false,
     };
@@ -423,9 +421,20 @@ export default {
       await this.QuestionStore.SetAddImage(false);
       this.$emit("comment");
     },
+    handleFileUpload(event) {
+      const files = Array.from(event.target.files);
+      if (files.length > 0) {
+        this.inlineImages.push(...files);
+      }
+      event.target.value = '';
+    },
+    removeInlineImage(index) {
+      this.inlineImages.splice(index, 1);
+    },
     toggleInlineAnswer(isEdit = false) {
       this.isAnswering = true;
       this.isEditingAnswer = isEdit;
+      this.inlineImages = [];
       if (isEdit && this.question.answers && this.question.answers.length > 0) {
         this.inlineAnswerBody = this.question.answers[0].body || "";
       } else {
@@ -437,8 +446,7 @@ export default {
     cancelInlineAnswer() {
       this.isAnswering = false;
       this.inlineAnswerBody = "";
-      this.inlineSelectedImages = [];
-      this.inlinePreviewImages = [];
+      this.inlineImages = [];
     },
     async submitInlineAnswer() {
       if (!this.inlineAnswerBody.trim()) return;
@@ -451,56 +459,12 @@ export default {
         }
         await this.QuestionStore.EditAnswer(this.inlineAnswerBody);
       } else {
-        await this.QuestionStore.AddAnswer(this.inlineAnswerBody, this.inlineSelectedImages);
+        await this.QuestionStore.AddAnswer(this.inlineAnswerBody, this.inlineImages);
       }
       
       this.isAnswering = false;
       this.inlineAnswerBody = "";
-      this.inlineSelectedImages = [];
-      this.inlinePreviewImages = [];
-    },
-    AddInlineImages() {
-      if(this.$refs.inlineFileInput) this.$refs.inlineFileInput.click();
-    },
-    SelectInlineFiles(e) {
-      if(e.target.files.length === 0) return;
-      
-      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
-      const maxSize = 10 * 1024 * 1024; // 10MB
-      
-      const filesToAdd = [];
-      Array.from(e.target.files).forEach((file) => {
-        if (!allowedTypes.includes(file.type)) {
-          alert(`File "${file.name}" is not a supported image format. Please upload JPEG, PNG, or GIF.`);
-          return;
-        }
-        if (file.size > maxSize) {
-          alert(`File "${file.name}" exceeds the maximum size of 10MB.`);
-          return;
-        }
-        filesToAdd.push(file);
-      });
-      
-      if (filesToAdd.length === 0) {
-        e.target.value = null;
-        return;
-      }
-
-      this.inlineSelectedImages.push(...filesToAdd);
-      filesToAdd.forEach((image) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-          if (reader.readyState === 2) {
-            this.inlinePreviewImages.push(reader.result);
-          }
-        };
-        reader.readAsDataURL(image);
-      });
-      e.target.value = null;
-    },
-    RemoveInlineImage(index) {
-      this.inlineSelectedImages.splice(index, 1);
-      this.inlinePreviewImages.splice(index, 1);
+      this.inlineImages = [];
     },
     async CommentClick() {
       await this.QuestionStore.SetQuestion(this.question);
@@ -620,12 +584,23 @@ export default {
   min-width: 0;
 }
 
+.question-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  gap: 12px;
+  width: 100%;
+}
+
 .question-meta {
   display: flex;
   align-items: center;
   gap: 6px;
   margin-bottom: 5px;
   white-space: nowrap;
+  min-width: 0;
+  flex: 1;
 }
 
 .avatar {
@@ -651,6 +626,9 @@ export default {
   line-height: 1;
   font-weight: 800;
   color: #1c1b1f;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dot {
@@ -666,6 +644,7 @@ export default {
   line-height: 1;
   font-weight: 400;
   color: #777777;
+  flex-shrink: 0;
 }
 
 .admin-actions {
@@ -718,6 +697,38 @@ export default {
   color: #1c1b1f;
 }
 
+.selected-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.image-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #f0f0f0;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  color: #333;
+}
+
+.image-pill button {
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+}
+.image-pill button:hover {
+  color: #d32f2f;
+}
+
 .question-side {
   display: flex;
   align-items: center;
@@ -736,6 +747,7 @@ export default {
   font-size: 13px;
   line-height: 1;
   font-weight: 700;
+  flex-shrink: 0;
 }
 
 .subject-pill,

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -16,67 +16,66 @@ export const useAuthStore = defineStore("auth", {
   persist: true,
   actions: {
     async Login(uid, password, sso) {
-      let info = {};
       const questionStore = useQuestionStore();
       const colourStore = useColourStore();
+      let res; // We will store the fetch response here for both paths
+
       if (sso) {
         console.log("login with sso");
         const urlParams = new URLSearchParams(window.location.search);
         const authorizationCode = urlParams.get("code");
         console.log(authorizationCode);
 
-        const res = await fetch(`${import.meta.env.VITE_API_BASE}/user/smplogin`, {
+        // Make ONE request to the securely updated backend route
+        res = await fetch(`${import.meta.env.VITE_API_BASE}/user/smplogin`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ authCode: authorizationCode }),
         });
-        const data = await res.json();
-        console.log("data from smp login :", data);
-        uid = data.rollNumber;
-        console.log("SMP KEY :", SMP_KEY);
-        info = {
-          user_ID: data.rollNumber,
-          password: SMP_KEY,
-        };
+
       } else {
         console.log("normal login");
-
-        info = {
+        const info = {
           user_ID: uid,
           password: password,
         };
+
+        // Make standard login request
+        res = await fetch(`${import.meta.env.VITE_API_BASE}/user/login`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(info),
+        });
       }
 
-      const res = await fetch(`${import.meta.env.VITE_API_BASE}/user/login`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(info),
-      });
-
-      if (res.status == 200) {
+      // Handle the response identically for both SSO and Normal Login
+      if (res.status === 200) {
         const data = await res.json();
         console.log("data :", data);
-        this.accessToken = data["accessToken"];
-        console.log("access token: " + this.accessToken);
+        
+        this.accessToken = data.accessToken; // Now the backend actually sends this!
         this.loggedIn = true;
-        this.user_ID = uid;
-        this.name = data["name"];
-        this.role = data["role"];
+        this.user_ID = data.user_ID || uid; 
+        this.name = data.name;
+        this.role = data.role;
+        
         console.log("logged in as :", this.loggedIn);
         console.log("user id :", this.user_ID);
         console.log("role :", this.role);
-        console.log("name :", this.name);
+        
+        // Redirect to dashboard
         window.location.href = import.meta.env.VITE_BASE + "/";
       } else {
-        console.log("logging out from login");
+        console.log("Login failed");
         const data = await res.json();
         console.log("data :", data);
+        
         await questionStore.SetShowSnackBar(true);
-        await questionStore.SetSnackMessage(data.message);
+        await questionStore.SetSnackMessage(data.message || "Invalid Credentials");
         await colourStore.SetSnackColor(false);
       }
     },

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -373,6 +373,10 @@ export const useQuestionStore = defineStore("question", {
         const data = await res.json();
         console.log('data :', data);
         this.snackMessage = data.message;
+        const listStore = useListStore();
+        if (data.data) {
+          listStore.list.unshift(data.data);
+        }
         await colourStore.SetSnackColor(true);
       } else {
         if (res.status === 403) {
@@ -396,8 +400,11 @@ export const useQuestionStore = defineStore("question", {
             console.log("snackbar");
             console.log("new request sent");
             const data = await res.json();
-            console.log('data :', data);
             this.snackMessage = data.message;
+            const listStore = useListStore();
+            if (data.data) {
+              listStore.list.unshift(data.data);
+            }
           } else {
             console.log("refresh failed");
             await this.authStore.Logout();
@@ -1511,60 +1518,7 @@ export const useQuestionStore = defineStore("question", {
         }
       }
     },
-    async DeleteInfoPost() {
-      const authStore = useAuthStore();
-      const listStore = useListStore();
-      const colourStore = useColourStore();
-      console.log("deleting infopost in question.js", this.info_ID);
 
-      const accessToken = authStore.accessToken;
-      const bearer = `Bearer ${accessToken}`;
-
-      const res = await fetch(`${import.meta.env.VITE_API_BASE}/info/delete/${this.info_ID}`, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: bearer,
-        },
-      });
-
-      this.showSnackbar = true;
-      if (res.status == 200) {
-        console.log("successfully deleted the info post :", this.info_ID);
-        const data = await res.json();
-        this.snackMessage = data.message;
-        colourStore.SetSnackColor(true);
-        // Assuming we need to remove from listStore. Let's filter out the deleted infopost in listStore or let component reload
-        listStore.list = listStore.list.filter(item => item._id !== this.info_ID && item.id !== this.info_ID);
-      } else {
-        if (res.status === 403) {
-          await authStore.Refresh();
-          if (authStore.loggedIn) {
-            const bearer = `Bearer ${authStore.accessToken}`;
-            const res = await fetch(`${import.meta.env.VITE_API_BASE}/info/delete/${this.info_ID}`, {
-              method: "DELETE",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: bearer,
-              },
-            });
-            this.showSnackbar = true;
-            const data = await res.json();
-            this.snackMessage = data.message;
-            colourStore.SetSnackColor(true);
-            listStore.list = listStore.list.filter(item => item._id !== this.info_ID && item.id !== this.info_ID);
-            return data;
-          } else {
-            await this.authStore.Logout();
-          }
-        } else {
-          this.showSnackbar = true;
-          this.snackMessage = "not enough permissions";
-          colourStore.SetSnackColor(false);
-          await this.authStore.Logout();
-        }
-      }
-    },
     async EditAnswer(body) {
       const authStore = useAuthStore();
       const listStore = useListStore();

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -421,6 +421,7 @@ export const useQuestionStore = defineStore("question", {
     async AddAnswer(body, images) {
       const authStore = useAuthStore();
       const colourStore = useColourStore();
+      const listStore = useListStore();
       console.log("we have entered the add answer function in question.js");
 
       console.log("images : ", images);
@@ -461,7 +462,9 @@ export const useQuestionStore = defineStore("question", {
         console.log('data :', data);
         this.snackMessage = data.message;
         await colourStore.SetSnackColor(true);
-        window.location.href = import.meta.env.VITE_BASE + "/answered";
+        if (data.data) {
+          await listStore.UpsertQuestion(data.data);
+        }
       } else {
         if (res.status === 403) {
           console.log("refreshing token");
@@ -489,10 +492,9 @@ export const useQuestionStore = defineStore("question", {
             const data = await res.json();
             console.log('data :', data);
             this.snackMessage = data.message;
-            window.location.href = import.meta.env.VITE_BASE + "/answered";
-            window.onload = function () {
-              window.location.href = import.meta.env.VITE_BASE + "/question";
-            };
+            if (data.data) {
+              await listStore.UpsertQuestion(data.data);
+            }
             return data;
           } else {
             console.log("refresh failed");

--- a/src/views/Answered.vue
+++ b/src/views/Answered.vue
@@ -57,11 +57,13 @@ export default {
   },
   data() {
     return {
-      questions: [],
       searchQuery: "",
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       if (!this.searchQuery.trim()) return this.questions;
       const fuse = new Fuse(this.questions, {
@@ -143,7 +145,6 @@ export default {
       this.questionStore.FetchAnnouncementsCount(),
       this.questionStore.FetchUnansweredCount()
     ]);
-    this.questions = this.listStore.list;
     console.log(this.questions);
     this.colourStore.colourAnswered();
   },

--- a/src/views/Infopost.vue
+++ b/src/views/Infopost.vue
@@ -78,13 +78,15 @@ export default {
   data() {
     return {
       networkError: false,
-      infoposts: [],
       searchQuery: "",
       windowWidth: window.innerWidth,
     };
   },
 
   computed: {
+    infoposts() {
+      return this.listStore.list || [];
+    },
     filteredInfoposts() {
       if (!this.searchQuery.trim()) {
         return this.infoposts;
@@ -201,9 +203,6 @@ export default {
       console.log("Selected tag:", tag);
 
       await this.fetchInfoPosts(tag);
-
-      this.infoposts = this.listStore.list;
-
       console.log(this.infoposts);
     },
     handleResize() {
@@ -217,7 +216,6 @@ export default {
       this.questionStore.FetchUnansweredCount()
     ]);
 
-    this.infoposts = this.listStore.list;
     this.questionStore.announcementsCount = this.infoposts.length;
 
     console.log(this.infoposts);

--- a/src/views/MyQuestions.vue
+++ b/src/views/MyQuestions.vue
@@ -64,11 +64,13 @@ export default {
   data() {
     return {
       networkError: false,
-      questions: [],
       searchQuery: "",
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       if (!this.searchQuery.trim()) {
         return this.questions;
@@ -152,7 +154,6 @@ export default {
   async mounted() {
     await this.colourStore.colourMyQuestions();
     await this.fetchQuestions();
-    this.questions = this.listStore.list || [];
     console.log(this.questions);
   },
 };

--- a/src/views/Questions.vue
+++ b/src/views/Questions.vue
@@ -101,7 +101,6 @@ export default {
   data() {
     return {
       networkError: false,
-      questions: [],
       searchQuery: "",
       categories: [
         "Hostel",
@@ -120,6 +119,9 @@ export default {
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       let result = [...this.questions];
 
@@ -233,7 +235,6 @@ export default {
     },
     async handleTagSelected(tag) {
       await this.fetchQuestions(tag);
-      this.questions = this.listStore.list || [];
     },
     handleResize() {
       this.windowWidth = window.innerWidth;
@@ -275,7 +276,6 @@ export default {
       this.questionStore.FetchAnnouncementsCount(),
       this.questionStore.FetchUnansweredCount()
     ]);
-    this.questions = this.listStore.list || [];
     this.colourStore.colourQuestions();
     window.addEventListener("resize", this.handleResize);
   },

--- a/src/views/Questions.vue
+++ b/src/views/Questions.vue
@@ -468,7 +468,8 @@ export default {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 12px;
+    row-gap: 14px;
     margin-top: 18px;
     width: 100%;
   }
@@ -526,7 +527,8 @@ export default {
 
   .category-row {
     order: 4;
-    gap: 8px;
+    gap: 15px;
+    row-gap: 14px;
     margin-top: 18px;
     width: 100%;
     display: flex;

--- a/src/views/Questionview.vue
+++ b/src/views/Questionview.vue
@@ -53,13 +53,11 @@
           </div>
         </div>
         <p>{{ answerBody }}</p>
-
-        <div class="preview" v-if="answerImages.length > 0">
-          <div v-for="(image, index) in answerImages" :key="index" class="PreImage">
-            <img :src="image" alt="Attachment" @click.stop="$emit('expand', image)" />
-          </div>
+        <div v-if="answerImages && answerImages.length > 0" class="answer-images-container">
+          <a v-for="img in answerImages" :key="img" :href="getImageUrl(img)" target="_blank" rel="noopener noreferrer">
+            <img :src="getImageUrl(img)" alt="Answer attachment" class="answer-attachment-img" />
+          </a>
         </div>
-
         <time>{{ answerTimestamp }}</time>
       </article>
     </section>
@@ -210,6 +208,9 @@ export default {
     answerTimestamp() {
       return this.formatShortDate(this.primaryAnswer.asked_At || this.primaryAnswer.timestamp);
     },
+    answerImages() {
+      return this.primaryAnswer.images || [];
+    },
   },
   methods: {
     loadQuestion(id) {
@@ -259,6 +260,10 @@ export default {
     async ensureQuestionSelected() {
       await this.questionStore.SetQuestion(this.question);
       await this.questionStore.SetQuestionID(this.question._id || this.question.id);
+    },
+    getImageUrl(filename) {
+      if (!filename) return "";
+      return `${import.meta.env.VITE_API_BASE}/uploads/${filename}`;
     },
     async submitComment() {
       const text = this.commentText.trim();
@@ -531,6 +536,26 @@ h1 {
   font-size: 12px;
   line-height: 1.25;
   font-weight: 500;
+}
+
+.answer-images-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 12px 0;
+}
+
+.answer-attachment-img {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 8px;
+  object-fit: cover;
+  border: 1px solid #ddd;
+  transition: transform 0.2s ease;
+}
+
+.answer-attachment-img:hover {
+  transform: scale(1.02);
 }
 
 .answer-card time {

--- a/src/views/UnAnswered.vue
+++ b/src/views/UnAnswered.vue
@@ -57,11 +57,13 @@ export default {
   },
   data() {
     return {
-      questions: [],
       searchQuery: "",
     };
   },
   computed: {
+    questions() {
+      return this.listStore.list || [];
+    },
     filteredQuestions() {
       if (!this.searchQuery.trim()) return this.questions;
       const fuse = new Fuse(this.questions, {
@@ -143,7 +145,6 @@ export default {
       this.questionStore.FetchAnnouncementsCount(),
       this.questionStore.FetchUnansweredCount()
     ]);
-    this.questions = this.listStore.list;
     console.log(this.questions);
     this.colourStore.colourUnAnswered();
   },


### PR DESCRIPTION
### Description
This PR resolves multiple outstanding UI/UX issues related to the mentorship portal's answering workflow, particularly on mobile devices.

### Key Changes
* **State Preservation on Answer:** Modifying the `AddAnswer` API flow to inject the backend response directly into the local Vue store (`UpsertQuestion`). This stops the forced redirect to the `/answered` route, meaning mentors no longer lose their active filters or search queries after answering a question.
* **Mobile Attachment Support:** The inline "Add attachment" button in `questionBox.vue` is now fully functional. Users can attach images to their answers (complete with a removable pill UI tracking selected files), and these images successfully post to the backend payload.
* **Attachment Rendering:** Updated `Questionview.vue` to dynamically pull image filenames from the answer object and render them cleanly beneath the mentor's text response.
* **Responsive Mobile Fixes:** 
  * Fixed an overflow bug on extremely narrow devices (e.g., 360px width) where the "Answered" tag would break out of the question card. The author's name now intelligently truncates with an ellipsis (`...`) while protecting the pill and timestamp.
  * Added breathing room (`row-gap: 14px`) to the wrapped filter and category tags in `Questions.vue` so they no longer squish together vertically on mobile screens.

### Testing Instructions
1. Verify seamless, reload-free answer submissions on the desktop feed (filters should remain active).
2. Test image uploads via the inline answer component on both desktop and mobile networks.
3. Verify visual alignment on narrow displays (360x740 / iPhone SE dimensions).
